### PR TITLE
Fix unescaped string.

### DIFF
--- a/resources/views/livewire/crud/create.blade.php
+++ b/resources/views/livewire/crud/create.blade.php
@@ -8,7 +8,7 @@
         </div>
         <div class="col-md-3">
             <div class="form-group">
-                <input id="route" type="text" placeholder="{{ __('CRUD's Route') }}" class="form-control rounded @error('route') is-invalid @enderror" wire:model="route">
+                <input id="route" type="text" placeholder="{{ __('CRUD\'s Route') }}" class="form-control rounded @error('route') is-invalid @enderror" wire:model="route">
                 @error('route') <div class="invalid-feedback">{{ $message }}</div> @enderror
             </div>
         </div>


### PR DESCRIPTION
Hi, I'm creating this PR to fix an unescaped string that breaks the CRUD page.

![image](https://user-images.githubusercontent.com/25041169/126724315-83a9b5f9-f2bf-447c-9119-2c0e327755d5.png)
