### PR TITLE
Fix lowercase in XxxComponent's model namespace

### DIFF
--- a/src/Http/Livewire/CRUD/Create.php
+++ b/src/Http/Livewire/CRUD/Create.php
@@ -74,10 +74,10 @@ class Create extends Component
         }
 
         try{
-            $name = strtolower($this->getModelName($this->model));
+            $name = $this->getModelName($this->model);
             CRUD::create([
                 'model' => trim($this->model, '\\'),
-                'name' => $name,
+                'name' => strtolower($name),
                 'route' => trim($this->route, '\\'),
                 'icon' => $this->icon ?? 'fas fa-bars'
             ]);


### PR DESCRIPTION
<img width="1326" alt="ScreenShot 2021-12-28 23 53 26" src="https://user-images.githubusercontent.com/35098175/147578548-bcd8b6d0-e49d-4b4d-b0ad-2a92f2bf8bfd.png">

`use App\Models\book;` in `app/CRUD/BookComponent.php` 

<img width="406" alt="ScreenShot 2021-12-28 23 48 36" src="https://user-images.githubusercontent.com/35098175/147578185-2b52d451-efe8-4db7-b0e3-148acc336e6d.png">
