### PR TITLE
Fix dropTables bug on panel:reinstall command

### DIFF
--- a/src/Commands/Actions/Uninstall.php
+++ b/src/Commands/Actions/Uninstall.php
@@ -29,6 +29,8 @@ class Uninstall extends Command
         // Drop tables which has been created by EasyPanel
         $this->dropTables();
 
+        $this->deleteMigrations();
+
         $this->info("All files and components was deleted!");
     }
 
@@ -36,11 +38,6 @@ class Uninstall extends Command
     {
         Schema::dropIfExists('cruds');
         Schema::dropIfExists('panel_admins');
-        
-        DB::table('migrations')->whereIn('migration', [
-            "2022_04_12_999999_create_cruds_table",
-            "2022_04_12_999999_create_user_admins_table"
-        ])->delete();
     }
 
     private function deleteFiles()
@@ -55,5 +52,17 @@ class Uninstall extends Command
         File::delete(LangManager::getFiles());
     }
 
+    private function deleteMigrations()
+    {
+        $migrationFiles = File::allFiles(__DIR__."/../../../database/migrations");
 
+        $migrationsTable = DB::table('migrations');
+        foreach ($migrationFiles as $migration) {
+            $migrationName = \Illuminate\Support\Str::between($migration->getFileName(), "999999", ".php");
+
+            $migrationsTable->orWhere('migration', 'like', "%$migrationName");
+        }
+
+        $migrationsTable->delete();
+    }
 }

--- a/src/Commands/Actions/Uninstall.php
+++ b/src/Commands/Actions/Uninstall.php
@@ -3,6 +3,7 @@
 namespace EasyPanel\Commands\Actions;
 
 use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Schema;
 use EasyPanel\Support\Contract\LangManager;
@@ -35,6 +36,11 @@ class Uninstall extends Command
     {
         Schema::dropIfExists('cruds');
         Schema::dropIfExists('panel_admins');
+        
+        DB::table('migrations')->whereIn('migration', [
+            "2022_04_12_999999_create_cruds_table",
+            "2022_04_12_999999_create_user_admins_table"
+        ])->delete();
     }
 
     private function deleteFiles()


### PR DESCRIPTION
After running the `panel: reinstall` command, tables `cruds` and `panel_admins` won't be migrated because they're still in the migrations table.

I added a delete migrations query to fix it.