### PR TITLE
[FIX] issue of case-sensitive file path in linux (unix base system)

### DIFF
--- a/src/helpers.php
+++ b/src/helpers.php
@@ -13,10 +13,14 @@ if(! function_exists('getRouteName')) {
 
 if(! function_exists('getCrudConfig')) {
     function getCrudConfig($name){
-        $namespace = "\\App\\CRUD\\{$name}Component";
+        $className = ucwords($name);
+        $namespace = "\\App\\CRUD\\{$className}Component";
+        $appFilePath = app_path("/CRUD/{$name}Component.php");
+        $nsExist = class_exists($namespace);
+        $filePathExist = file_exists($appFilePath);
 
-        if (!file_exists(app_path("/CRUD/{$name}Component.php")) or !class_exists($namespace)){
-            abort(403, "Class with {$namespace} namespace doesn't exist");
+        if (!$filePathExist or !$nsExist){
+            abort(403, "Class with {$namespace}  namespace or {$appFilePath} doesn't exist, ");
         }
 
         $instance = app()->make($namespace);


### PR DESCRIPTION

## Issue description:

In Windows operating systems, file paths are not case-sensitive. On the other hand, Unix-based operating systems, such as Linux and macOS, are case-sensitive. This means that you must use the exact capitalization of the file path to access the file correctly.

**In Windows:* You could open a file named "MyDocument.docx" using any of the following paths:

- `C:\Users\Documents\MyDocument.docx`
- `c:\users\documents\mydocument.docx`
- `C:\USERS\DOCUMENTS\MYDOCUMENT.DOCX`
- 
**In Linux:** If the file is actually named "MyDocument.docx" (with a capital "D"), you would only be able to open it using the path `"/home/user/Documents/MyDocument.docx"`. Using `"/home/user/documents/mydocument.docx"` would not work, as the system would treat it as a different file.

Related:
#46 #34

## Proposed method:
by using native php method `ucwords` at  `src/helpers.php` in `getCrudConfig` function.
so it does n't matter `user` or `USER` for it and result always should be:
```php
/CRUD/UserComponent.php
```

TODO:
- [x] check in linux os
- [x] check in docker (alpine)
- [ ] check in windows os